### PR TITLE
Fix static property mutation error

### DIFF
--- a/html/newscript.js
+++ b/html/newscript.js
@@ -66,33 +66,23 @@ class Color {
             otherColor.getBlue() === this.#b;
     }
 
-    cycle() {
-        if (this.equals(Color.OFF)) {
-            this.#r = 255;
-            this.#g = 0;
-            this.#b = 0;
-        } else if (this.equals(Color.RED)) {
-            this.#r = 0;
-            this.#g = 255;
-            this.#b = 0;
-        } else if (this.equals(Color.GREEN)) {
-            this.#r = 0;
-            this.#g = 0;
-            this.#b = 255;
-        } else if (this.equals(Color.BLUE)) {
-            this.#r = 255;
-            this.#g = 255;
-            this.#b = 0;
-        } else if (this.equals(Color.YELLOW)) {
-            this.#r = 255;
-            this.#g = 255;
-            this.#b = 255;
-        } else if (this.equals(Color.WHITE)) {
-            this.#r = 0;
-            this.#g = 0;
-            this.#b = 0;
-        } else {
-            throw new Error("Unknown color " + this.toString());
+    cycle(frame, band) {
+        const colors = [Color.OFF, 
+                        Color.RED, 
+                        Color.GREEN, 
+                        Color.BLUE, 
+                        Color.YELLOW, 
+                        Color.WHITE];
+
+        colors.forEach((color,i) => {
+            if (this.equals(color)) {
+                frame[band] = i < colors.length - 1 ? colors[i + 1] : colors[0];
+                colors.splice(i, 1);
+            }
+        });
+        
+        if (colors.length === 6) {
+            throw new Error("Unknown color: {r: " + this.#r + ", g: " + this.#g + ", b: " + this.#b + "}");
         }
     }
 
@@ -582,12 +572,13 @@ $(document).ready(function () {
         anim.setFrameColor(currentFrame, Color.OFF, Color.OFF, Color.OFF, Color.OFF, Color.OFF);
     });
 
-    // Bind click event on band 1 button
-    $('#band1Container').click(function () {
-        let currentFrame = parseInt(frameSelectDropdown.val());
-
-        console.log(Color.RED);
-        anim.getFrame(currentFrame).bandColor1.cycle();
-        anim.getFrame(currentFrame).setActive();
-    });
+    // Bind click event on band buttons
+    for (let i = 1; i < 6; i++) {
+        $(`#band${i}Container`).click(function () {
+            const currentFrame = parseInt(frameSelectDropdown.val());
+            const frame = anim.getFrame(currentFrame);
+            frame[`bandColor${i}`].cycle(frame, `bandColor${i}`);
+            frame.setActive();
+        });
+    }
 });


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

Fixes #1 

I found the error here - take a look at where `anim` is defined (lines 308-322 in the original `newscript.js` file). Each individual band has its color set using a static property (i.e. `Color.OFF`, `Color.RED`, etc.), but that static property returns a Color object, the properties of which can then be altered by later code. As written, cycle() accesses this color object and changes its properties instead of passing a new Color object in to the bandColor1 property.

A relatively straightforward way to fix it is to change the cycle() method so that it no longer mutates the Color object of the band, but instead assigns a new Color object to the relevant frame and band. I assumed the intent was for this effect to apply to all bands, so I also edited the code so that it binds the relevant function to each band.

An alternate way to fix it would be to change the static properties to be static getters. That way the static getter would return a color object, but when that object's #r, #g, #b properties are altered by cycle(), it would not change the original object. 